### PR TITLE
[bugfix] Fix Release Pipeline YAML Indentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,15 +94,15 @@ jobs:
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:
-      tag_name: ${{ steps.commit_info.outputs.tag_name }}
-      name: "Nanvix Binutils ${{ steps.commit_info.outputs.tag_name }}"
-      body: |
-        Automated release of Nanvix Binutils v2.40
+        tag_name: ${{ steps.commit_info.outputs.tag_name }}
+        name: "Nanvix Binutils ${{ steps.commit_info.outputs.tag_name }}"
+        body: |
+          Automated release of Nanvix Binutils v2.40
 
-        Built from commit: ${{ github.sha }}
+          Built from commit: ${{ github.sha }}
 
-        This release contains the complete Binutils toolchain configured for the Nanvix operating system target (i686-nanvix).
-      files: |
-        ${{ steps.commit_info.outputs.zip_name }}
-      draft: false
-      prerelease: false
+          This release contains the complete Binutils toolchain configured for the Nanvix operating system target (i686-nanvix).
+        files: |
+          ${{ steps.commit_info.outputs.zip_name }}
+        draft: false
+        prerelease: false


### PR DESCRIPTION
This PR fixes the YAML indentation issue in the release pipeline workflow.

## Changes Made
- Fixed improper indentation in the 'Create GitHub Release' step
- All parameters under the  section are now properly indented
- The workflow should now parse correctly and be able to create releases

## Related Issues
This fixes the workflow that was previously failing due to YAML syntax errors.

## Testing
- [ ] YAML syntax validation passes
- [ ] Workflow can be triggered successfully