### PR TITLE
[devops] Release Command for `z` Utility

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,9 +38,9 @@ This project uses a custom `z` utility script for streamlined building and insta
 
 # Complete build process
 ./z setup      # Install required system packages
-./z configure  # Configure for your system
-./z build      # Compile the binutils
-./z install    # Install to default location ($HOME)
+./z configure  # Configure the build
+./z build      # Compile the source code
+./z install    # Install to default location
 ```
 
 ## Contributing Guidelines

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,6 +41,7 @@ This project uses a custom `z` utility script for streamlined building and insta
 ./z configure  # Configure the build
 ./z build      # Compile the source code
 ./z install    # Install to default location
+./z release    # Create a release zip file
 ```
 
 ## Contributing Guidelines

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       id: commit_info
       run: |
         SHORT_SHA=$(git rev-parse --short HEAD)
-        TAG_NAME="nanvix/v2.40-${SHORT_SHA}"
+        TAG_NAME="nanvix-v2.40-${SHORT_SHA}"
         RELEASE_NAME="nanvix-binutils-v2.40-${SHORT_SHA}"
         echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
         echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
@@ -79,7 +79,7 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         tag_name: ${{ steps.commit_info.outputs.tag_name }}
-        name: "Nanvix Binutils ${{ steps.commit_info.outputs.tag_name }}"
+        name: "${{ steps.commit_info.outputs.tag_name }}"
         body: |
           Automated release of Nanvix Binutils v2.40
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,27 +51,15 @@ jobs:
     - name: Install dependencies
       run: sudo ./z setup
 
-    - name: Create release directory
-      run: sudo mkdir -p ${{ env.RELEASE_INSTALL_LOCATION }}
-
-    - name: Configure Binutils for release
-      run: ./z configure --install-location=${{ env.RELEASE_INSTALL_LOCATION }}
-
-    - name: Build Binutils
-      run: ./z build
-
-    - name: Install Binutils to release location
-      run: sudo ./z install
-
     - name: Get commit information
       id: commit_info
       run: |
         SHORT_SHA=$(git rev-parse --short HEAD)
         TAG_NAME="nanvix/v2.40-${SHORT_SHA}"
-        ZIP_NAME="nanvix-binutils-v2.40-${SHORT_SHA}.zip"
+        RELEASE_NAME="nanvix-binutils-v2.40-${SHORT_SHA}"
         echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
         echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
-        echo "zip_name=${ZIP_NAME}" >> $GITHUB_OUTPUT
+        echo "release_name=${RELEASE_NAME}" >> $GITHUB_OUTPUT
 
     - name: Fast-forward nanvix/v2.40 branch to dev
       run: |
@@ -80,11 +68,7 @@ jobs:
         git push origin nanvix/v2.40
 
     - name: Create release archive
-      run: |
-        cd /opt
-        sudo zip -r "${{ steps.commit_info.outputs.zip_name }}" nanvix/
-        sudo mv "${{ steps.commit_info.outputs.zip_name }}" ${{ github.workspace }}/
-        sudo chown $USER:$USER ${{ github.workspace }}/${{ steps.commit_info.outputs.zip_name }}
+      run: ./z release --install-location=${{ env.RELEASE_INSTALL_LOCATION }} --release-name=${{ steps.commit_info.outputs.release_name }}
 
     - name: Create release tag
       run: |
@@ -103,6 +87,6 @@ jobs:
 
           This release contains the complete Binutils toolchain configured for the Nanvix operating system target (i686-nanvix).
         files: |
-          ${{ steps.commit_info.outputs.zip_name }}
+          ${{ steps.commit_info.outputs.release_name }}.zip
         draft: false
         prerelease: false

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ stamp-*
 
 # Ignore build artifacts for Nanvix
 # TODO: Find a better way to handle this.
+/*.zip
 Makefile
 bfd/elf32-aarch64.c
 bfd/elf32-loongarch.c

--- a/z
+++ b/z
@@ -200,8 +200,6 @@ configure_binutils() {
     # Check for required development tools
     check_required_tools
 
-    export TARGET="$TARGET"
-
     ./configure \
         --target="$TARGET" \
         --prefix="$INSTALL_LOCATION" \

--- a/z
+++ b/z
@@ -268,7 +268,7 @@ setup_packages() {
     fi
 
     # Install missing packages from REQUIRED_PACKAGES
-    echo "Installing packages: ${REQUIRED_PACKAGES[@]}"
+    echo "Installing packages:" "${REQUIRED_PACKAGES[@]}"
     if [[ $EUID -eq 0 ]]; then
         apt-get install -y "${REQUIRED_PACKAGES[@]}"
     else

--- a/z
+++ b/z
@@ -171,9 +171,9 @@ show_help() {
     cat << EOF
 Utility for building and installing Binutils for the Nanvix operating system.
 
-Usage: ./z COMMAND [OPTIONS]
-       ./z ${BUILD_CMD_NAME} [${PARALLEL_BUILD_OPT_NAME}=N] (defaults to using all available CPU cores)
-       ./z ${CONFIGURE_CMD_NAME} [${INSTALL_LOCATION_OPT_NAME}=PATH] (defaults to ${DEFAULT_INSTALL_LOCATION})
+Usage: ./z COMMAND   [OPTIONS]
+       ./z ${BUILD_CMD_NAME}     [${PARALLEL_BUILD_OPT_NAME}=N]
+       ./z ${CONFIGURE_CMD_NAME} [${INSTALL_LOCATION_OPT_NAME}=PATH]
        ./z ${HELP_CMD_NAME}
        ./z ${INSTALL_CMD_NAME}
        ./z ${SETUP_CMD_NAME}
@@ -186,8 +186,8 @@ Commands:
   ${SETUP_CMD_NAME}        Install required packages to build Binutils for Nanvix
 
 Options:
-  ${INSTALL_LOCATION_OPT_NAME}=PATH    Set install location to 'PATH'.
-  ${PARALLEL_BUILD_OPT_NAME}=N         Use parallel threads when building.
+  ${INSTALL_LOCATION_OPT_NAME}=PATH    Set install location to 'PATH'          (defaults to '${DEFAULT_INSTALL_LOCATION}')
+  ${PARALLEL_BUILD_OPT_NAME}=N         Use 'N' parallel threads when building  (defaults to using all available CPU cores)
 EOF
 }
 

--- a/z
+++ b/z
@@ -258,9 +258,9 @@ release_binutils() {
 
     echo "Creating release..."
     local oldpwd=${PWD}
-    pushd "$INSTALL_LOCATION" || exit 1
+    pushd "$INSTALL_LOCATION" || { print_error "Failed to change directory to ${INSTALL_LOCATION}"; exit 1; }
     zip -r "${oldpwd}/${RELEASE_NAME}.zip" .
-    popd || exit 1
+    popd || { print_error "Failed to return to the previous directory after creating the release"; exit 1; }
     echo "Release created: ${RELEASE_NAME}.zip"
 }
 
@@ -308,6 +308,10 @@ parse_args() {
                 ;;
             "${PARALLEL_BUILD_OPT_NAME}="*)
                 PARALLEL_BUILD="${1#*=}"
+                shift
+                ;;
+            "${RELEASE_NAME_OPT_NAME}="*)
+                RELEASE_NAME="${1#*=}"
                 shift
                 ;;
             *)

--- a/z
+++ b/z
@@ -14,15 +14,18 @@ BUILD_CMD_NAME="build"
 CONFIGURE_CMD_NAME="configure"
 HELP_CMD_NAME="help"
 INSTALL_CMD_NAME="install"
+RELEASE_CMD_NAME="release"
 SETUP_CMD_NAME="setup"
 
 # Option Names
 INSTALL_LOCATION_OPT_NAME="--install-location"
 PARALLEL_BUILD_OPT_NAME="--parallel-build"
+RELEASE_NAME_OPT_NAME="--release-name"
 
 # Default Values
 TARGET="i686-nanvix"
 DEFAULT_INSTALL_LOCATION="$HOME"
+DEFAULT_RELEASE_NAME="nanvix-binutils"
 
 # Required Build Tools
 REQUIRED_TOOLS=("gcc" "make")
@@ -37,6 +40,7 @@ REQUIRED_PACKAGES=("libmpfr-dev" "libgmp-dev" "build-essential")
 
 INSTALL_LOCATION="$DEFAULT_INSTALL_LOCATION"
 PARALLEL_BUILD=""
+RELEASE_NAME="$DEFAULT_RELEASE_NAME"
 
 #==================================================================================================
 # Functions
@@ -176,6 +180,7 @@ Usage: ./z COMMAND   [OPTIONS]
        ./z ${CONFIGURE_CMD_NAME} [${INSTALL_LOCATION_OPT_NAME}=PATH]
        ./z ${HELP_CMD_NAME}
        ./z ${INSTALL_CMD_NAME}
+       ./z ${RELEASE_CMD_NAME}   [${RELEASE_NAME_OPT_NAME}=NAME] [${PARALLEL_BUILD_OPT_NAME}=N] [${INSTALL_LOCATION_OPT_NAME}=PATH]
        ./z ${SETUP_CMD_NAME}
 
 Commands:
@@ -183,11 +188,13 @@ Commands:
   ${CONFIGURE_CMD_NAME}    Configure Binutils for Nanvix
   ${HELP_CMD_NAME}         Print help
   ${INSTALL_CMD_NAME}      Install Binutils for Nanvix
+  ${RELEASE_CMD_NAME}      Create a release of Binutils for Nanvix
   ${SETUP_CMD_NAME}        Install required packages to build Binutils for Nanvix
 
 Options:
   ${INSTALL_LOCATION_OPT_NAME}=PATH    Set install location to 'PATH'          (defaults to '${DEFAULT_INSTALL_LOCATION}')
   ${PARALLEL_BUILD_OPT_NAME}=N         Use 'N' parallel threads when building  (defaults to using all available CPU cores)
+  ${RELEASE_NAME_OPT_NAME}=NAME        Set the release name to 'NAME'          (defaults to '${DEFAULT_RELEASE_NAME}')
 EOF
 }
 
@@ -241,6 +248,20 @@ install_binutils() {
     make install
 
     echo "Installation completed successfully."
+}
+
+# Release Binutils
+release_binutils() {
+    configure_binutils
+    build_binutils
+    install_binutils
+
+    echo "Creating release..."
+    local oldpwd=${PWD}
+    pushd "$INSTALL_LOCATION" || exit 1
+    zip -r "${oldpwd}/${RELEASE_NAME}.zip" .
+    popd || exit 1
+    echo "Release created: ${RELEASE_NAME}.zip"
 }
 
 # Setup required system packages listed in REQUIRED_PACKAGES
@@ -331,6 +352,10 @@ main() {
         "${INSTALL_CMD_NAME}")
             parse_args "$@"
             install_binutils
+            ;;
+        "${RELEASE_CMD_NAME}")
+            parse_args "$@"
+            release_binutils
             ;;
         "${SETUP_CMD_NAME}")
             parse_args "$@"

--- a/z
+++ b/z
@@ -28,11 +28,11 @@ DEFAULT_INSTALL_LOCATION="$HOME"
 DEFAULT_RELEASE_NAME="nanvix-binutils"
 
 # Required Build Tools
-REQUIRED_TOOLS=("gcc" "make")
-REQUIRED_TOOLS_VERSION=("13.3.0" "4.3.0")
+REQUIRED_TOOLS=("gcc" "make" "zip")
+REQUIRED_TOOLS_VERSION=("13.3.0" "4.3.0" "3.0.0")
 
 # Required System Packages for Setup
-REQUIRED_PACKAGES=("libmpfr-dev" "libgmp-dev" "build-essential")
+REQUIRED_PACKAGES=("libmpfr-dev" "libgmp-dev" "build-essential" "zip")
 
 #==================================================================================================
 # Global Variables
@@ -98,6 +98,18 @@ normalize_tool_version() {
     echo "$version"
 }
 
+# Get the version of a tool.
+get_tool_version() {
+    local tool="$1"
+    local version
+    version=$("$tool" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1)
+    if [[ -z "$version" ]]; then
+        print_error "Unable to determine $tool version"
+        exit 1
+    fi
+    echo "$version"
+}
+
 # Check for required development tools.
 check_required_tools() {
     echo "Checking for required development tools..."
@@ -113,7 +125,7 @@ check_required_tools() {
 
         # Get version string.
         local version
-        version=$("$tool" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1)
+        version=$(get_tool_version "$tool")
         if [[ -z "$version" ]]; then
             print_error "Unable to determine $tool version"
             exit 1


### PR DESCRIPTION
This pull request introduces a new `release` command to the custom `z` utility script, streamlining the process of creating release archives for the Nanvix Binutils. It also updates the GitHub Actions workflow to integrate this new functionality, replacing manual steps with the `z release` command. Below are the most significant changes:

### Enhancements to the `z` Utility Script:
* Added a `release` command to the `z` script, which automates the process of configuring, building, installing, and creating a release archive for Binutils. This includes support for specifying a custom release name using the `--release-name` option. (`z`: [[1]](diffhunk://#diff-594e519ae499312b29433b7dd8a97ff068defcba9755b6d5d00e84c524d67b06R17-R28) [[2]](diffhunk://#diff-594e519ae499312b29433b7dd8a97ff068defcba9755b6d5d00e84c524d67b06R43) [[3]](diffhunk://#diff-594e519ae499312b29433b7dd8a97ff068defcba9755b6d5d00e84c524d67b06L175-R197) [[4]](diffhunk://#diff-594e519ae499312b29433b7dd8a97ff068defcba9755b6d5d00e84c524d67b06R255-R268) [[5]](diffhunk://#diff-594e519ae499312b29433b7dd8a97ff068defcba9755b6d5d00e84c524d67b06R315-R318) [[6]](diffhunk://#diff-594e519ae499312b29433b7dd8a97ff068defcba9755b6d5d00e84c524d67b06R362-R365)

### Updates to GitHub Actions Workflow:
* Replaced multiple manual steps in the release workflow with a single `z release` command, simplifying the process of creating release archives. This includes updates to use the `--release-name` option for naming the release. (`.github/workflows/release.yml`: [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L54-R62) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L83-R71)
* Updated the release tag and file name references to align with the new `z release` command's output. (`.github/workflows/release.yml`: [.github/workflows/release.ymlL98-R90](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L98-R90))

### Documentation Updates:
* Updated the `copilot-instructions.md` file to include the new `release` command in the build process documentation. (`.github/copilot-instructions.md`: [.github/copilot-instructions.mdL41-R44](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L41-R44))

These changes collectively improve the efficiency and maintainability of the release process for the Nanvix Binutils.