### PR TITLE
[devops] Fix Cancel Rule for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ on:
 # Cancel previous running actions for the same PR
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/dev' }}
 
 #==================================================================================================
 # Environment Variables
@@ -43,7 +43,7 @@ jobs:
     # Only run the CI for:
     # - Pushes to 'dev' (handled by workflow triggers above)
     # - Non-draft PRs where the source branch starts with one of:
-    #     'enhancement-', 'feature-', 'bugfix-', ''dependabot/', or 'copilot/'
+    #     'enhancement-', 'feature-', 'bugfix-', 'dependabot/', or 'copilot/'
     if: |
       github.event_name != 'pull_request' ||
       (


### PR DESCRIPTION
This pull request makes minor adjustments to the GitHub Actions CI workflow configuration. The changes update the concurrency cancellation condition to better align with the project's development flow and correct a comment regarding branch name patterns.

- Workflow concurrency:
  * Changed the `cancel-in-progress` concurrency condition so that only runs for the `dev` branch are not cancelled, instead of the `main` branch. This ensures that concurrent workflow runs are cancelled for all branches except `dev`.

- Documentation/comment correction:
  * Fixed a comment to accurately reflect that the CI runs for PRs from branches starting with `'dependabot/'` (removed an extra single quote and fixed the pattern).