### PR TITLE
fix: make package visibility step non-fatal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,12 +148,12 @@ jobs:
     - name: Make package public
       if: steps.check_release.outputs.exists == 'false'
       run: |
-        curl --fail-with-body -sS -X PATCH \
+        curl -fsS -X PATCH \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           "https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/binutils" \
-          -d '{"visibility":"public"}'
+          -d '{"visibility":"public"}' || true
 
     #----------------------------------------------------------------------------------------------
     # Git Operations


### PR DESCRIPTION
The 'Make package public' curl call returns 404 if the GHCR package doesn't exist yet at the org API level or if GITHUB_TOKEN lacks admin:packages scope. This caused the release pipeline to fail after a successful build+push.

Fix: replace `--fail-with-body` with `-fsS` (consistent with other workflows) and add `|| true` so this best-effort step doesn't block the release.