### PR TITLE
feat: dispatch binutils-release to llvm-project

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,3 +220,19 @@ jobs:
               "binutils_sha": "${{ steps.commit_info.outputs.short_sha }}"
             }
           }'
+
+    - name: Dispatch to llvm-project
+      if: steps.check_release.outputs.exists == 'false'
+      run: |
+        curl -fsS -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${{ secrets.DISPATCH_TOKEN }}" \
+          https://api.github.com/repos/nanvix/llvm-project/dispatches \
+          -d '{
+            "event_type": "binutils-release",
+            "client_payload": {
+              "binutils_version": "${{ env.BINUTILS_VERSION }}",
+              "binutils_tag": "${{ steps.commit_info.outputs.tag_name }}",
+              "binutils_sha": "${{ steps.commit_info.outputs.short_sha }}"
+            }
+          }'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,9 @@ jobs:
 
     - name: Prepare Docker context
       if: steps.check_release.outputs.exists == 'false'
-      run: cp -r ${{ env.INSTALL_LOCATION }} ./docker-install
+      run: |
+        mkdir -p ./docker-install
+        cp -r "${{ env.INSTALL_LOCATION }}/." ./docker-install/
 
     - name: Set up Docker Buildx
       if: steps.check_release.outputs.exists == 'false'


### PR DESCRIPTION
Add `repository_dispatch` to `nanvix/llvm-project` alongside the existing dispatch to `nanvix/gcc`, enabling the Clang toolchain release chain:

```
binutils → llvm-project(stage 0) → newlib → llvm-project(stage 1) → toolchain-clang
```

**Changes:**
- `release.yml`: dispatch `binutils-release` event to `nanvix/llvm-project` with binutils tag/sha payload

Part of the standalone Clang toolchain initiative. Related PRs in nanvix/llvm-project, nanvix/newlib, nanvix/toolchain-clang.