### PR TITLE
Add CODEOWNERS file to auto-request reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for all files
+* @ppenna


### PR DESCRIPTION
Adds `@ppenna` as default code owner so all PRs automatically request review, ensuring proper notification and review coverage.